### PR TITLE
worktree: return err before use sync.PutByteSlice

### DIFF
--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -58,11 +58,15 @@ func WritePackfileToObjectStorage(
 
 	buf := sync.GetByteSlice()
 	n, err = io.CopyBuffer(w, packfile, *buf)
-	sync.PutByteSlice(buf)
+	if err != nil {
+		return err
+	}
 
-	if err == nil && n == 0 {
+	if n == 0 {
 		return ErrEmptyPackfile
 	}
 
-	return err
+	sync.PutByteSlice(buf)
+
+	return nil
 }

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -88,8 +88,11 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 
 	b := sync.GetByteSlice()
 	_, err = io.CopyBuffer(w, dst, *b)
+	if err != nil {
+		return err
+	}
 	sync.PutByteSlice(b)
-	return err
+	return nil
 }
 
 // PatchDelta returns the result of applying the modification deltas in delta to src.
@@ -347,7 +350,6 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	mw := io.MultiWriter(dst, hasher)
 
 	bufp := sync.GetByteSlice()
-	defer sync.PutByteSlice(bufp)
 
 	sr := io.NewSectionReader(base, int64(0), int64(srcSz))
 	// Keep both the io.LimitedReader types, so we can reset N.
@@ -406,6 +408,7 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 		}
 	}
 
+	sync.PutByteSlice(bufp)
 	return targetSz, hasher.Sum(), nil
 }
 

--- a/worktree.go
+++ b/worktree.go
@@ -755,6 +755,10 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 	defer ioutil.CheckClose(to, &err)
 	buf := sync.GetByteSlice()
 	_, err = io.CopyBuffer(to, from, *buf)
+	if err != nil {
+		return
+	}
+
 	sync.PutByteSlice(buf)
 	return
 }


### PR DESCRIPTION
to avoid surprises in error cases